### PR TITLE
Decide text type at init

### DIFF
--- a/MapboxSpeech/MBSpeechOptions.swift
+++ b/MapboxSpeech/MBSpeechOptions.swift
@@ -119,7 +119,7 @@ open class SpeechOptions: NSObject, NSSecureCoding {
      
      `SSML` text must be valid `SSML` for request to work.
      */
-    var textType: TextType
+    @objc let textType: TextType
     
     
     /**

--- a/MapboxSpeechTests/MapboxVoiceTests.swift
+++ b/MapboxSpeechTests/MapboxVoiceTests.swift
@@ -35,7 +35,6 @@ class MapboxVoicZTests: XCTestCase {
         
         let voice = SpeechSynthesizer(accessToken: BogusToken)
         let options = SpeechOptions(text: "hello")
-        options.textType = .text
         options.outputFormat = .mp3
         
         var audio: Data?


### PR DESCRIPTION
There is no real reason to change the `textType` after initing with a certain type. This variable should be immutable.


/cc @1ec5 