### PR TITLE
Add neuter SpeechGender

### DIFF
--- a/MapboxSpeech/MBSpeechOptions.swift
+++ b/MapboxSpeech/MBSpeechOptions.swift
@@ -73,6 +73,8 @@ public enum SpeechGender: UInt, CustomStringConvertible {
     
     case male
     
+    case neuter
+    
     public init?(description: String) {
         let gender: SpeechGender
         switch description {
@@ -81,7 +83,7 @@ public enum SpeechGender: UInt, CustomStringConvertible {
         case "male":
             gender = .male
         default:
-            gender = .female
+            gender = .neuter
         }
         self.init(rawValue: gender.rawValue)
     }
@@ -92,6 +94,8 @@ public enum SpeechGender: UInt, CustomStringConvertible {
             return "female"
         case .male:
             return "male"
+        case .neuter:
+            return "neuter"
         }
     }
 }
@@ -175,7 +179,7 @@ open class SpeechOptions: NSObject, NSSecureCoding {
      
      Note: not all languages have both genders.
      */
-    @objc open var speechGender: SpeechGender = .female
+    @objc open var speechGender: SpeechGender = .neuter
     
     /**
      The path of the request URL, not including the hostname or any parameters.
@@ -189,12 +193,15 @@ open class SpeechOptions: NSObject, NSSecureCoding {
      An array of URL parameters to include in the request URL.
      */
     internal var params: [URLQueryItem] {
-        let params: [URLQueryItem] = [
+        var params: [URLQueryItem] = [
             URLQueryItem(name: "textType", value: String(describing: textType)),
             URLQueryItem(name: "language", value: locale.identifier),
-            URLQueryItem(name: "outputFormat", value: String(describing: outputFormat)),
-            URLQueryItem(name: "gender", value: String(describing: speechGender))
+            URLQueryItem(name: "outputFormat", value: String(describing: outputFormat))
         ]
+        
+        if speechGender != .neuter {
+            params.append(URLQueryItem(name: "gender", value: String(describing: speechGender)))
+        }
         
         return params
     }

--- a/MapboxSpeechTests/MapboxVoiceTests.swift
+++ b/MapboxSpeechTests/MapboxVoiceTests.swift
@@ -4,7 +4,7 @@ import OHHTTPStubs
 
 let BogusToken = "pk.foo-bar"
 
-class MapboxVoicZTests: XCTestCase {
+class MapboxVoiceTests: XCTestCase {
     
     override func setUp() {
         super.setUp()


### PR DESCRIPTION
Addresses: https://github.com/mapbox/mapbox-speech-swift/pull/5#pullrequestreview-90785544

If a `SpeechGender` is not specified, we should not default to a gender in this library, but rather have the API decide upon the default gender to use.

/cc @1ec5 