### PR TITLE
Rewrite readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
-# MapboxSpeech
+# Mapbox Speech
 
-A module for using the Mapbox Speech API specifically tuned for the [Mapbox Navigation SDK](https://www.mapbox.com/navigation/).
+Mapbox Speech connects your iOS application to the Mapbox Voice API. Take turn instructions from the [Mapbox Directions API](https://www.mapbox.com/api-documentation/#directions) and read them aloud naturally in multiple languages. This library is specifically designed to work with [MapboxDirections.swift](https://github.com/mapbox/MapboxDirections.swift/) as part of the [Mapbox Navigation SDK for iOS](https://github.com/mapbox/mapbox-navigation-ios/).
 
 ## Getting started
 
@@ -18,16 +18,69 @@ pod 'MapboxSpeech', '~> 0.1'
 
 Then `import MapboxSpeech` or `@import MapboxSpeech;`.
 
-## Basic Usage
+## Usage
+
+You’ll need a [Mapbox access token](https://www.mapbox.com/developers/api/#access-tokens) in order to use the API. If you’re already using the [Mapbox Maps SDK for iOS](https://www.mapbox.com/ios-sdk/) or [macOS SDK](https://mapbox.github.io/mapbox-gl-native/macos/), Mapbox Speech automatically recognizes your access token, as long as you’ve placed it in the `MGLMapboxAccessToken` key of your application’s Info.plist file.
+
+The examples below are each provided in Swift (denoted with `main.swift`) and Objective-C (`main.m`).
+
+### Basics
+
+The main speech synthesis class is SpeechSynthesizer (in Swift) or MBSpeechSynthesizer (in Objective-C). Create a speech synthesizer object using your access token:
 
 ```swift
 // main.swift
 import MapboxSpeech
 
-let voice = SpeechSynthesizer(accessToken: "Your Mapbox access token")
-let options = SpeechOptions(text: "hello, my name is Bobby")
+let speechSynthesizer = SpeechSynthesizer(accessToken: "<#your access token#>")
+```
 
-voice.audioData(with: options) { (data: Data?, error: NSError?) in
+```objc
+// main.m
+@import MapboxSpeech;
+
+MBSpeechSynthesizer *speechSynthesizer = [[MBSpeechSynthesizer alloc] initWithAccessToken:@"<#your access token#>"];
+```
+
+Alternatively, you can place your access token in the `MGLMapboxAccessToken` key of your application’s Info.plist file, then use the shared speech synthesizer object:
+
+```swift
+// main.swift
+let speechSynthesizer = SpeechSynthesizer.shared
+```
+
+```objc
+// main.m
+MBSpeechSynthesizer *speechSynthesizer = [MBSpeechSynthesizer sharedSpeech];
+```
+
+With the directions object in hand, construct a SpeechOptions or MBSpeechOptions object and pass it into the `SpeechSynthesizer.audioData(with:completionHandler:)` method.
+
+```swift
+// main.swift
+
+let options = SpeechOptions(text: "hello, my name is Bobby")
+speechSynthesizer.audioData(with: options) { (data: Data?, error: NSError?) in
+    guard error == nil else {
+        print("Error calculating directions: \(error!)")
+        return
+    }
+    
     // Do something with the audio!
 }
+```
+
+```objc
+// main.m
+
+MBSpeechOptions *options = [[MBSpeechOptions alloc] initWithText: "hello, my name is Bobby")
+[speechSynthesizer speakSpeechWithOptions:options completionHandler:^(NSData * _Nullable data,
+                                                                      NSError * _Nullable error) {
+    if (error) {
+        NSLog(@"Error synthesizing speech: %@", error);
+        return;
+    }
+    
+    // Do something with the audio!
+}];
 ```

--- a/readme.md
+++ b/readme.md
@@ -73,7 +73,7 @@ speechSynthesizer.audioData(with: options) { (data: Data?, error: NSError?) in
 ```objc
 // main.m
 
-MBSpeechOptions *options = [[MBSpeechOptions alloc] initWithText: "hello, my name is Bobby")
+MBSpeechOptions *options = [[MBSpeechOptions alloc] initWithText: "hello, my name is Bobby"];
 [speechSynthesizer speakSpeechWithOptions:options completionHandler:^(NSData * _Nullable data,
                                                                       NSError * _Nullable error) {
     if (error) {

--- a/readme.md
+++ b/readme.md
@@ -51,7 +51,7 @@ let speechSynthesizer = SpeechSynthesizer.shared
 
 ```objc
 // main.m
-MBSpeechSynthesizer *speechSynthesizer = [MBSpeechSynthesizer sharedSpeech];
+MBSpeechSynthesizer *speechSynthesizer = [MBSpeechSynthesizer sharedSpeechSynthesizer];
 ```
 
 With the directions object in hand, construct a SpeechOptions or MBSpeechOptions object and pass it into the `SpeechSynthesizer.audioData(with:completionHandler:)` method.
@@ -74,8 +74,8 @@ speechSynthesizer.audioData(with: options) { (data: Data?, error: NSError?) in
 // main.m
 
 MBSpeechOptions *options = [[MBSpeechOptions alloc] initWithText: "hello, my name is Bobby"];
-[speechSynthesizer speakSpeechWithOptions:options completionHandler:^(NSData * _Nullable data,
-                                                                      NSError * _Nullable error) {
+[speechSynthesizer audioDataWithOptions:options completionHandler:^(NSData * _Nullable data,
+                                                                    NSError * _Nullable error) {
     if (error) {
         NSLog(@"Error synthesizing speech: %@", error);
         return;


### PR DESCRIPTION
Fleshed out the readme based on the readme of MapboxDirections.swift. For consistency, the readme recommends using `SpeechSynthesizer.shared`, but we can revisit that as part of #10.

/cc @bsudekum @akitchen