### PR TITLE
Expose apiEndpoint and accessToken publicly

### DIFF
--- a/MapboxSpeech.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/MapboxSpeech.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/MapboxSpeech/MapboxSpeech.swift
+++ b/MapboxSpeech/MapboxSpeech.swift
@@ -74,10 +74,10 @@ open class SpeechSynthesizer: NSObject {
     public static let shared = SpeechSynthesizer(accessToken: nil)
     
     /// The API endpoint to request the audio from.
-    internal var apiEndpoint: URL
+    @objc public private(set) var apiEndpoint: URL
     
     /// The Mapbox access token to associate the request with.
-    internal let accessToken: String
+    @objc public let accessToken: String
     
     /**
      Initializes a newly created speech synthesizer object with an optional access token and host.


### PR DESCRIPTION
This is needed to validate the token in various cases, e.g. in a test case where `@testable` Debug builds should be avoided.

cc @1ec5 @akitchen 