### PR TITLE
Tighten up path escaping

### DIFF
--- a/MapboxSpeech/MBSpeechOptions.swift
+++ b/MapboxSpeech/MBSpeechOptions.swift
@@ -140,8 +140,9 @@ open class SpeechOptions: NSObject, Codable {
      The path of the request URL, not including the hostname or any parameters.
      */
     internal var path: String {
-        let disallowedCharacters = (CharacterSet(charactersIn: "\\!*'();:@&=+$,/<>?%#[]\" ").inverted)
-        return "voice/v1/speak/\(text.addingPercentEncoding(withAllowedCharacters: disallowedCharacters)!)"
+        var characterSet = CharacterSet.urlPathAllowed
+        characterSet.remove(charactersIn: "/")
+        return "voice/v1/speak/\(text.addingPercentEncoding(withAllowedCharacters: characterSet)!)"
     }
     
     /**


### PR DESCRIPTION
Speculatively fixed an issue where `SpeechSynthesizer.url(forSynthesizing:)` would crash because of a malformed path. When parsing URLs, it’s always a good idea to lean on standard library APIs that are documented to be RFC-compliant, rather than hand-rolling character sets and other logic. We received a report of this issue when the library is used with the Mapbox Navigation SDK and the Directions API, but I’m not sure what API response would’ve caused the path to contain a character that’s problematic when unescaped.

/cc @mapbox/navigation-ios @samfader