### PR TITLE
macOS, tvOS, watchOS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,13 +17,31 @@ step-library:
       run:
         name: Install Dependencies
         command: |
-          carthage bootstrap --platform ios
+          carthage bootstrap
     
     - &ios-build-test
       run:
-        name: Build and Test
+        name: Build and Test for iOS
         command: |
           xcodebuild -sdk iphonesimulator -destination 'platform=iOS Simulator,OS=12.1,name=iPhone X' -project MapboxSpeech.xcodeproj -scheme "MapboxSpeech iOS" clean build test
+    
+    - &macos-build-test
+      run:
+        name: Build and Test for macOS
+        command: |
+          xcodebuild -project MapboxSpeech.xcodeproj -scheme "MapboxSpeech Mac" clean build test
+    
+    - &tvos-build-test
+      run:
+        name: Build and Test for tvOS
+        command: |
+          xcodebuild -destination 'platform=tvOS Simulator,OS=12.1,name=Apple TV 4K (at 1080p)' -project MapboxSpeech.xcodeproj -scheme "MapboxSpeech tvOS" clean build test
+    
+    - &watchos-build
+      run:
+        name: Build for watchOS
+        command: |
+          xcodebuild -destination 'platform=watchOS Simulator,OS=5.1,name=Apple Watch Series 3 - 42mm' -project MapboxSpeech.xcodeproj -scheme "MapboxSpeech watchOS" clean build
 
 jobs:
   ios-build-test:
@@ -36,3 +54,6 @@ jobs:
       - *prepare
       - *install-dependencies
       - *ios-build-test
+      - *macos-build-test
+      - *tvos-build-test
+      - *watchos-build

--- a/MapboxSpeech.podspec
+++ b/MapboxSpeech.podspec
@@ -5,12 +5,12 @@ Pod::Spec.new do |s|
   s.name = "MapboxSpeech"
   s.version = "0.1.1"
 
-  s.summary = "A speech synthesizer built on AWS Polly for Swift and Objective-C."
+  s.summary = "A speech synthesizer built on Amazon Polly for Swift and Objective-C."
 
    s.description  = <<-DESC
-   MapboxSpeech makes it easy to connect your iOS, macOS, tvOS, or watchOS application to the Mapbox Speech API. Quickly get audio files from a text string.
+   MapboxSpeech makes it easy to connect your iOS, macOS, tvOS, or watchOS application to the Mapbox Voice API. Quickly get audio files from a text string.
                    DESC
-  s.homepage = "https://www.mapbox.com/ios-sdk/navigation/"
+  s.homepage = "https://docs.mapbox.com/ios/navigation/"
   #s.documentation_url = "https://www.mapbox.com/mapbox-navigation-ios/voice/"
 
   # ―――  Spec License  ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
@@ -25,11 +25,14 @@ Pod::Spec.new do |s|
   # ――― Platform Specifics ――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 
   s.ios.deployment_target = "8.0"
+  s.osx.deployment_target = "10.10"
+  s.tvos.deployment_target = "9.0"
+  s.watchos.deployment_target = "2.0"
 
 
   # ――― Source Location ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 
-  s.source = { :git => "https://github.com/mapbox/mapbox-voice-swift.git", :tag => "v#{s.version.to_s}" }
+  s.source = { :git => "https://github.com/mapbox/mapbox-speech-swift.git", :tag => "v#{s.version.to_s}" }
 
   # ――― Source Code ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 

--- a/MapboxSpeech.xcodeproj/project.pbxproj
+++ b/MapboxSpeech.xcodeproj/project.pbxproj
@@ -21,6 +21,13 @@
 		DAE3528D22420D3A00A3FF9C /* MapboxVoiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C54F535A1F6C754D00BFCC66 /* MapboxVoiceTests.swift */; };
 		DAE3528E22420D3D00A3FF9C /* hello.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = C5569E6C1FD9EEE100D9B7AC /* hello.mp3 */; };
 		DAE3529022420FDE00A3FF9C /* OHHTTPStubs.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DAE3528F22420FDE00A3FF9C /* OHHTTPStubs.framework */; };
+		DAE3529F224213ED00A3FF9C /* MapboxSpeech.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DAE35296224213ED00A3FF9C /* MapboxSpeech.framework */; };
+		DAE352AD2242150200A3FF9C /* MapboxSpeech.h in Headers */ = {isa = PBXBuildFile; fileRef = C54F534F1F6C754D00BFCC66 /* MapboxSpeech.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DAE352AE2242150600A3FF9C /* MapboxSpeech.swift in Sources */ = {isa = PBXBuildFile; fileRef = C54F53661F6C756B00BFCC66 /* MapboxSpeech.swift */; };
+		DAE352AF2242150900A3FF9C /* MBSpeechOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C54F53681F6C758C00BFCC66 /* MBSpeechOptions.swift */; };
+		DAE352B02242151100A3FF9C /* hello.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = C5569E6C1FD9EEE100D9B7AC /* hello.mp3 */; };
+		DAE352B12242151300A3FF9C /* MapboxVoiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C54F535A1F6C754D00BFCC66 /* MapboxVoiceTests.swift */; };
+		DAE352B32242157A00A3FF9C /* OHHTTPStubs.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DAE352B22242157A00A3FF9C /* OHHTTPStubs.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -38,6 +45,13 @@
 			remoteGlobalIDString = DAE3527222420CE900A3FF9C;
 			remoteInfo = MapboxSpeechMac;
 		};
+		DAE352A0224213ED00A3FF9C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C54F53431F6C754D00BFCC66 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DAE35295224213ED00A3FF9C;
+			remoteInfo = MapboxSpeechTV;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
@@ -54,6 +68,9 @@
 		DAE3527322420CE900A3FF9C /* MapboxSpeech.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MapboxSpeech.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DAE3527B22420CEA00A3FF9C /* MapboxSpeechTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MapboxSpeechTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		DAE3528F22420FDE00A3FF9C /* OHHTTPStubs.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OHHTTPStubs.framework; path = Carthage/Build/Mac/OHHTTPStubs.framework; sourceTree = "<group>"; };
+		DAE35296224213ED00A3FF9C /* MapboxSpeech.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MapboxSpeech.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		DAE3529E224213ED00A3FF9C /* MapboxSpeechTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MapboxSpeechTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		DAE352B22242157A00A3FF9C /* OHHTTPStubs.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OHHTTPStubs.framework; path = Carthage/Build/tvOS/OHHTTPStubs.framework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -89,6 +106,22 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		DAE35293224213ED00A3FF9C /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DAE3529B224213ED00A3FF9C /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DAE352B32242157A00A3FF9C /* OHHTTPStubs.framework in Frameworks */,
+				DAE3529F224213ED00A3FF9C /* MapboxSpeech.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -109,6 +142,8 @@
 				C54F53551F6C754D00BFCC66 /* MapboxSpeechTests.xctest */,
 				DAE3527322420CE900A3FF9C /* MapboxSpeech.framework */,
 				DAE3527B22420CEA00A3FF9C /* MapboxSpeechTests.xctest */,
+				DAE35296224213ED00A3FF9C /* MapboxSpeech.framework */,
+				DAE3529E224213ED00A3FF9C /* MapboxSpeechTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -137,6 +172,7 @@
 		C5569E671FD9E97300D9B7AC /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				DAE352B22242157A00A3FF9C /* OHHTTPStubs.framework */,
 				DAE3528F22420FDE00A3FF9C /* OHHTTPStubs.framework */,
 				C5569E681FD9E97400D9B7AC /* OHHTTPStubs.framework */,
 			);
@@ -167,6 +203,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				DAE3528A22420CFB00A3FF9C /* MapboxSpeech.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DAE35291224213ED00A3FF9C /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DAE352AD2242150200A3FF9C /* MapboxSpeech.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -245,6 +289,42 @@
 			productReference = DAE3527B22420CEA00A3FF9C /* MapboxSpeechTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		DAE35295224213ED00A3FF9C /* MapboxSpeechTV */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DAE352A7224213ED00A3FF9C /* Build configuration list for PBXNativeTarget "MapboxSpeechTV" */;
+			buildPhases = (
+				DAE35291224213ED00A3FF9C /* Headers */,
+				DAE35292224213ED00A3FF9C /* Sources */,
+				DAE35293224213ED00A3FF9C /* Frameworks */,
+				DAE35294224213ED00A3FF9C /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = MapboxSpeechTV;
+			productName = MapboxSpeechTV;
+			productReference = DAE35296224213ED00A3FF9C /* MapboxSpeech.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		DAE3529D224213ED00A3FF9C /* MapboxSpeechTVTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DAE352AA224213ED00A3FF9C /* Build configuration list for PBXNativeTarget "MapboxSpeechTVTests" */;
+			buildPhases = (
+				DAE3529A224213ED00A3FF9C /* Sources */,
+				DAE3529B224213ED00A3FF9C /* Frameworks */,
+				DAE3529C224213ED00A3FF9C /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				DAE352A1224213ED00A3FF9C /* PBXTargetDependency */,
+			);
+			name = MapboxSpeechTVTests;
+			productName = MapboxSpeechTVTests;
+			productReference = DAE3529E224213ED00A3FF9C /* MapboxSpeechTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -273,6 +353,14 @@
 						CreatedOnToolsVersion = 10.1;
 						ProvisioningStyle = Automatic;
 					};
+					DAE35295224213ED00A3FF9C = {
+						CreatedOnToolsVersion = 10.1;
+						ProvisioningStyle = Automatic;
+					};
+					DAE3529D224213ED00A3FF9C = {
+						CreatedOnToolsVersion = 10.1;
+						ProvisioningStyle = Automatic;
+					};
 				};
 			};
 			buildConfigurationList = C54F53461F6C754D00BFCC66 /* Build configuration list for PBXProject "MapboxSpeech" */;
@@ -291,6 +379,8 @@
 				C54F53541F6C754D00BFCC66 /* MapboxSpeechTests */,
 				DAE3527222420CE900A3FF9C /* MapboxSpeechMac */,
 				DAE3527A22420CEA00A3FF9C /* MapboxSpeechMacTests */,
+				DAE35295224213ED00A3FF9C /* MapboxSpeechTV */,
+				DAE3529D224213ED00A3FF9C /* MapboxSpeechTVTests */,
 			);
 		};
 /* End PBXProject section */
@@ -323,6 +413,21 @@
 			buildActionMask = 2147483647;
 			files = (
 				DAE3528E22420D3D00A3FF9C /* hello.mp3 in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DAE35294224213ED00A3FF9C /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DAE3529C224213ED00A3FF9C /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DAE352B02242151100A3FF9C /* hello.mp3 in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -363,6 +468,23 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		DAE35292224213ED00A3FF9C /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DAE352AE2242150600A3FF9C /* MapboxSpeech.swift in Sources */,
+				DAE352AF2242150900A3FF9C /* MBSpeechOptions.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DAE3529A224213ED00A3FF9C /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DAE352B12242151300A3FF9C /* MapboxVoiceTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -375,6 +497,11 @@
 			isa = PBXTargetDependency;
 			target = DAE3527222420CE900A3FF9C /* MapboxSpeechMac */;
 			targetProxy = DAE3527D22420CEA00A3FF9C /* PBXContainerItemProxy */;
+		};
+		DAE352A1224213ED00A3FF9C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DAE35295224213ED00A3FF9C /* MapboxSpeechTV */;
+			targetProxy = DAE352A0224213ED00A3FF9C /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -697,6 +824,114 @@
 			};
 			name = Release;
 		};
+		DAE352A8224213ED00A3FF9C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = MapboxSpeech/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxSpeech;
+				PRODUCT_NAME = MapboxSpeech;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+			};
+			name = Debug;
+		};
+		DAE352A9224213ED00A3FF9C /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = MapboxSpeech/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxSpeech;
+				PRODUCT_NAME = MapboxSpeech;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+			};
+			name = Release;
+		};
+		DAE352AB224213ED00A3FF9C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/tvOS",
+				);
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = MapboxSpeechTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks $(PROJECT_DIR)/Carthage/Build/tvOS";
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxSpeechTests;
+				PRODUCT_NAME = MapboxSpeechTests;
+				SDKROOT = appletvos;
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+			};
+			name = Debug;
+		};
+		DAE352AC224213ED00A3FF9C /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/tvOS",
+				);
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = MapboxSpeechTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks $(PROJECT_DIR)/Carthage/Build/tvOS";
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxSpeechTests;
+				PRODUCT_NAME = MapboxSpeechTests;
+				SDKROOT = appletvos;
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -741,6 +976,24 @@
 			buildConfigurations = (
 				DAE3528822420CEA00A3FF9C /* Debug */,
 				DAE3528922420CEA00A3FF9C /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		DAE352A7224213ED00A3FF9C /* Build configuration list for PBXNativeTarget "MapboxSpeechTV" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DAE352A8224213ED00A3FF9C /* Debug */,
+				DAE352A9224213ED00A3FF9C /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		DAE352AA224213ED00A3FF9C /* Build configuration list for PBXNativeTarget "MapboxSpeechTVTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DAE352AB224213ED00A3FF9C /* Debug */,
+				DAE352AC224213ED00A3FF9C /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/MapboxSpeech.xcodeproj/project.pbxproj
+++ b/MapboxSpeech.xcodeproj/project.pbxproj
@@ -14,6 +14,13 @@
 		C54F53691F6C758C00BFCC66 /* MBSpeechOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C54F53681F6C758C00BFCC66 /* MBSpeechOptions.swift */; };
 		C5569E6A1FD9EA5700D9B7AC /* OHHTTPStubs.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C5569E681FD9E97400D9B7AC /* OHHTTPStubs.framework */; };
 		C5569E6D1FD9EEE100D9B7AC /* hello.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = C5569E6C1FD9EEE100D9B7AC /* hello.mp3 */; };
+		DAE3527C22420CEA00A3FF9C /* MapboxSpeech.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DAE3527322420CE900A3FF9C /* MapboxSpeech.framework */; };
+		DAE3528A22420CFB00A3FF9C /* MapboxSpeech.h in Headers */ = {isa = PBXBuildFile; fileRef = C54F534F1F6C754D00BFCC66 /* MapboxSpeech.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DAE3528B22420D1F00A3FF9C /* MapboxSpeech.swift in Sources */ = {isa = PBXBuildFile; fileRef = C54F53661F6C756B00BFCC66 /* MapboxSpeech.swift */; };
+		DAE3528C22420D3200A3FF9C /* MBSpeechOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C54F53681F6C758C00BFCC66 /* MBSpeechOptions.swift */; };
+		DAE3528D22420D3A00A3FF9C /* MapboxVoiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C54F535A1F6C754D00BFCC66 /* MapboxVoiceTests.swift */; };
+		DAE3528E22420D3D00A3FF9C /* hello.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = C5569E6C1FD9EEE100D9B7AC /* hello.mp3 */; };
+		DAE3529022420FDE00A3FF9C /* OHHTTPStubs.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DAE3528F22420FDE00A3FF9C /* OHHTTPStubs.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -23,6 +30,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = C54F534B1F6C754D00BFCC66;
 			remoteInfo = MapboxVoice;
+		};
+		DAE3527D22420CEA00A3FF9C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C54F53431F6C754D00BFCC66 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DAE3527222420CE900A3FF9C;
+			remoteInfo = MapboxSpeechMac;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -37,6 +51,9 @@
 		C54F53681F6C758C00BFCC66 /* MBSpeechOptions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MBSpeechOptions.swift; sourceTree = "<group>"; };
 		C5569E681FD9E97400D9B7AC /* OHHTTPStubs.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OHHTTPStubs.framework; path = Carthage/Build/iOS/OHHTTPStubs.framework; sourceTree = "<group>"; };
 		C5569E6C1FD9EEE100D9B7AC /* hello.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = hello.mp3; sourceTree = "<group>"; };
+		DAE3527322420CE900A3FF9C /* MapboxSpeech.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MapboxSpeech.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		DAE3527B22420CEA00A3FF9C /* MapboxSpeechTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MapboxSpeechTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		DAE3528F22420FDE00A3FF9C /* OHHTTPStubs.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OHHTTPStubs.framework; path = Carthage/Build/Mac/OHHTTPStubs.framework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -53,6 +70,22 @@
 			files = (
 				C5569E6A1FD9EA5700D9B7AC /* OHHTTPStubs.framework in Frameworks */,
 				C54F53561F6C754D00BFCC66 /* MapboxSpeech.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DAE3527022420CE900A3FF9C /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DAE3527822420CEA00A3FF9C /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DAE3529022420FDE00A3FF9C /* OHHTTPStubs.framework in Frameworks */,
+				DAE3527C22420CEA00A3FF9C /* MapboxSpeech.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -74,6 +107,8 @@
 			children = (
 				C54F534C1F6C754D00BFCC66 /* MapboxSpeech.framework */,
 				C54F53551F6C754D00BFCC66 /* MapboxSpeechTests.xctest */,
+				DAE3527322420CE900A3FF9C /* MapboxSpeech.framework */,
+				DAE3527B22420CEA00A3FF9C /* MapboxSpeechTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -102,6 +137,7 @@
 		C5569E671FD9E97300D9B7AC /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				DAE3528F22420FDE00A3FF9C /* OHHTTPStubs.framework */,
 				C5569E681FD9E97400D9B7AC /* OHHTTPStubs.framework */,
 			);
 			name = Frameworks;
@@ -123,6 +159,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				C54F535D1F6C754D00BFCC66 /* MapboxSpeech.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DAE3526E22420CE900A3FF9C /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DAE3528A22420CFB00A3FF9C /* MapboxSpeech.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -165,13 +209,49 @@
 			productReference = C54F53551F6C754D00BFCC66 /* MapboxSpeechTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		DAE3527222420CE900A3FF9C /* MapboxSpeechMac */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DAE3528422420CEA00A3FF9C /* Build configuration list for PBXNativeTarget "MapboxSpeechMac" */;
+			buildPhases = (
+				DAE3526E22420CE900A3FF9C /* Headers */,
+				DAE3526F22420CE900A3FF9C /* Sources */,
+				DAE3527022420CE900A3FF9C /* Frameworks */,
+				DAE3527122420CE900A3FF9C /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = MapboxSpeechMac;
+			productName = MapboxSpeechMac;
+			productReference = DAE3527322420CE900A3FF9C /* MapboxSpeech.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		DAE3527A22420CEA00A3FF9C /* MapboxSpeechMacTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DAE3528722420CEA00A3FF9C /* Build configuration list for PBXNativeTarget "MapboxSpeechMacTests" */;
+			buildPhases = (
+				DAE3527722420CEA00A3FF9C /* Sources */,
+				DAE3527822420CEA00A3FF9C /* Frameworks */,
+				DAE3527922420CEA00A3FF9C /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				DAE3527E22420CEA00A3FF9C /* PBXTargetDependency */,
+			);
+			name = MapboxSpeechMacTests;
+			productName = MapboxSpeechMacTests;
+			productReference = DAE3527B22420CEA00A3FF9C /* MapboxSpeechTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
 		C54F53431F6C754D00BFCC66 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 0830;
+				LastSwiftUpdateCheck = 1010;
 				LastUpgradeCheck = 1010;
 				ORGANIZATIONNAME = Mapbox;
 				TargetAttributes = {
@@ -183,6 +263,14 @@
 					C54F53541F6C754D00BFCC66 = {
 						CreatedOnToolsVersion = 8.3.3;
 						LastSwiftMigration = 0910;
+						ProvisioningStyle = Automatic;
+					};
+					DAE3527222420CE900A3FF9C = {
+						CreatedOnToolsVersion = 10.1;
+						ProvisioningStyle = Automatic;
+					};
+					DAE3527A22420CEA00A3FF9C = {
+						CreatedOnToolsVersion = 10.1;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -201,6 +289,8 @@
 			targets = (
 				C54F534B1F6C754D00BFCC66 /* MapboxSpeech */,
 				C54F53541F6C754D00BFCC66 /* MapboxSpeechTests */,
+				DAE3527222420CE900A3FF9C /* MapboxSpeechMac */,
+				DAE3527A22420CEA00A3FF9C /* MapboxSpeechMacTests */,
 			);
 		};
 /* End PBXProject section */
@@ -218,6 +308,21 @@
 			buildActionMask = 2147483647;
 			files = (
 				C5569E6D1FD9EEE100D9B7AC /* hello.mp3 in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DAE3527122420CE900A3FF9C /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DAE3527922420CEA00A3FF9C /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DAE3528E22420D3D00A3FF9C /* hello.mp3 in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -241,6 +346,23 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		DAE3526F22420CE900A3FF9C /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DAE3528B22420D1F00A3FF9C /* MapboxSpeech.swift in Sources */,
+				DAE3528C22420D3200A3FF9C /* MBSpeechOptions.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DAE3527722420CEA00A3FF9C /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DAE3528D22420D3A00A3FF9C /* MapboxVoiceTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -248,6 +370,11 @@
 			isa = PBXTargetDependency;
 			target = C54F534B1F6C754D00BFCC66 /* MapboxSpeech */;
 			targetProxy = C54F53571F6C754D00BFCC66 /* PBXContainerItemProxy */;
+		};
+		DAE3527E22420CEA00A3FF9C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DAE3527222420CE900A3FF9C /* MapboxSpeechMac */;
+			targetProxy = DAE3527D22420CEA00A3FF9C /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -303,6 +430,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -360,6 +488,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
@@ -456,6 +585,118 @@
 			};
 			name = Release;
 		};
+		DAE3528522420CEA00A3FF9C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_VERSION = A;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = MapboxSpeech/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxSpeech;
+				PRODUCT_NAME = MapboxSpeech;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
+			};
+			name = Debug;
+		};
+		DAE3528622420CEA00A3FF9C /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_VERSION = A;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = MapboxSpeech/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxSpeech;
+				PRODUCT_NAME = MapboxSpeech;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
+			};
+			name = Release;
+		};
+		DAE3528822420CEA00A3FF9C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = "";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/Mac",
+				);
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = MapboxSpeechTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks $(PROJECT_DIR)/Carthage/Build/Mac";
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxSpeechTests;
+				PRODUCT_NAME = MapboxSpeechTests;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 4.0;
+			};
+			name = Debug;
+		};
+		DAE3528922420CEA00A3FF9C /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = "";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/Mac",
+				);
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = MapboxSpeechTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks $(PROJECT_DIR)/Carthage/Build/Mac";
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxSpeechTests;
+				PRODUCT_NAME = MapboxSpeechTests;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 4.0;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -482,6 +723,24 @@
 			buildConfigurations = (
 				C54F53641F6C754D00BFCC66 /* Debug */,
 				C54F53651F6C754D00BFCC66 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		DAE3528422420CEA00A3FF9C /* Build configuration list for PBXNativeTarget "MapboxSpeechMac" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DAE3528522420CEA00A3FF9C /* Debug */,
+				DAE3528622420CEA00A3FF9C /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		DAE3528722420CEA00A3FF9C /* Build configuration list for PBXNativeTarget "MapboxSpeechMacTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DAE3528822420CEA00A3FF9C /* Debug */,
+				DAE3528922420CEA00A3FF9C /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/MapboxSpeech.xcodeproj/project.pbxproj
+++ b/MapboxSpeech.xcodeproj/project.pbxproj
@@ -28,6 +28,9 @@
 		DAE352B02242151100A3FF9C /* hello.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = C5569E6C1FD9EEE100D9B7AC /* hello.mp3 */; };
 		DAE352B12242151300A3FF9C /* MapboxVoiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C54F535A1F6C754D00BFCC66 /* MapboxVoiceTests.swift */; };
 		DAE352B32242157A00A3FF9C /* OHHTTPStubs.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DAE352B22242157A00A3FF9C /* OHHTTPStubs.framework */; };
+		DAE352C12242169F00A3FF9C /* MapboxSpeech.h in Headers */ = {isa = PBXBuildFile; fileRef = C54F534F1F6C754D00BFCC66 /* MapboxSpeech.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DAE352C2224216A300A3FF9C /* MapboxSpeech.swift in Sources */ = {isa = PBXBuildFile; fileRef = C54F53661F6C756B00BFCC66 /* MapboxSpeech.swift */; };
+		DAE352C3224216A500A3FF9C /* MBSpeechOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C54F53681F6C758C00BFCC66 /* MBSpeechOptions.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -71,6 +74,7 @@
 		DAE35296224213ED00A3FF9C /* MapboxSpeech.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MapboxSpeech.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DAE3529E224213ED00A3FF9C /* MapboxSpeechTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MapboxSpeechTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		DAE352B22242157A00A3FF9C /* OHHTTPStubs.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OHHTTPStubs.framework; path = Carthage/Build/tvOS/OHHTTPStubs.framework; sourceTree = "<group>"; };
+		DAE352B92242165D00A3FF9C /* MapboxSpeech.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MapboxSpeech.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -122,6 +126,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		DAE352B62242165D00A3FF9C /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -144,6 +155,7 @@
 				DAE3527B22420CEA00A3FF9C /* MapboxSpeechTests.xctest */,
 				DAE35296224213ED00A3FF9C /* MapboxSpeech.framework */,
 				DAE3529E224213ED00A3FF9C /* MapboxSpeechTests.xctest */,
+				DAE352B92242165D00A3FF9C /* MapboxSpeech.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -211,6 +223,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				DAE352AD2242150200A3FF9C /* MapboxSpeech.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DAE352B42242165D00A3FF9C /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DAE352C12242169F00A3FF9C /* MapboxSpeech.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -325,6 +345,24 @@
 			productReference = DAE3529E224213ED00A3FF9C /* MapboxSpeechTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		DAE352B82242165D00A3FF9C /* MapboxSpeechWatch */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DAE352C02242165D00A3FF9C /* Build configuration list for PBXNativeTarget "MapboxSpeechWatch" */;
+			buildPhases = (
+				DAE352B42242165D00A3FF9C /* Headers */,
+				DAE352B52242165D00A3FF9C /* Sources */,
+				DAE352B62242165D00A3FF9C /* Frameworks */,
+				DAE352B72242165D00A3FF9C /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = MapboxSpeechWatch;
+			productName = MapboxSpeechWatch;
+			productReference = DAE352B92242165D00A3FF9C /* MapboxSpeech.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -361,6 +399,10 @@
 						CreatedOnToolsVersion = 10.1;
 						ProvisioningStyle = Automatic;
 					};
+					DAE352B82242165D00A3FF9C = {
+						CreatedOnToolsVersion = 10.1;
+						ProvisioningStyle = Automatic;
+					};
 				};
 			};
 			buildConfigurationList = C54F53461F6C754D00BFCC66 /* Build configuration list for PBXProject "MapboxSpeech" */;
@@ -381,6 +423,7 @@
 				DAE3527A22420CEA00A3FF9C /* MapboxSpeechMacTests */,
 				DAE35295224213ED00A3FF9C /* MapboxSpeechTV */,
 				DAE3529D224213ED00A3FF9C /* MapboxSpeechTVTests */,
+				DAE352B82242165D00A3FF9C /* MapboxSpeechWatch */,
 			);
 		};
 /* End PBXProject section */
@@ -428,6 +471,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				DAE352B02242151100A3FF9C /* hello.mp3 in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DAE352B72242165D00A3FF9C /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -482,6 +532,15 @@
 			buildActionMask = 2147483647;
 			files = (
 				DAE352B12242151300A3FF9C /* MapboxVoiceTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DAE352B52242165D00A3FF9C /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DAE352C2224216A300A3FF9C /* MapboxSpeech.swift in Sources */,
+				DAE352C3224216A500A3FF9C /* MBSpeechOptions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -932,6 +991,65 @@
 			};
 			name = Release;
 		};
+		DAE352BE2242165D00A3FF9C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = MapboxSpeech/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxSpeech;
+				PRODUCT_NAME = MapboxSpeech;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Debug;
+		};
+		DAE352BF2242165D00A3FF9C /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = MapboxSpeech/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxSpeech;
+				PRODUCT_NAME = MapboxSpeech;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -994,6 +1112,15 @@
 			buildConfigurations = (
 				DAE352AB224213ED00A3FF9C /* Debug */,
 				DAE352AC224213ED00A3FF9C /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		DAE352C02242165D00A3FF9C /* Build configuration list for PBXNativeTarget "MapboxSpeechWatch" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DAE352BE2242165D00A3FF9C /* Debug */,
+				DAE352BF2242165D00A3FF9C /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/MapboxSpeech.xcodeproj/xcshareddata/xcschemes/MapboxSpeech Mac.xcscheme
+++ b/MapboxSpeech.xcodeproj/xcshareddata/xcschemes/MapboxSpeech Mac.xcscheme
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1010"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DAE3527222420CE900A3FF9C"
+               BuildableName = "MapboxSpeech.framework"
+               BlueprintName = "MapboxSpeechMac"
+               ReferencedContainer = "container:MapboxSpeech.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DAE3527A22420CEA00A3FF9C"
+               BuildableName = "MapboxSpeechTests.xctest"
+               BlueprintName = "MapboxSpeechMacTests"
+               ReferencedContainer = "container:MapboxSpeech.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DAE3527222420CE900A3FF9C"
+            BuildableName = "MapboxSpeech.framework"
+            BlueprintName = "MapboxSpeechMac"
+            ReferencedContainer = "container:MapboxSpeech.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DAE3527222420CE900A3FF9C"
+            BuildableName = "MapboxSpeech.framework"
+            BlueprintName = "MapboxSpeechMac"
+            ReferencedContainer = "container:MapboxSpeech.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DAE3527222420CE900A3FF9C"
+            BuildableName = "MapboxSpeech.framework"
+            BlueprintName = "MapboxSpeechMac"
+            ReferencedContainer = "container:MapboxSpeech.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/MapboxSpeech.xcodeproj/xcshareddata/xcschemes/MapboxSpeech tvOS.xcscheme
+++ b/MapboxSpeech.xcodeproj/xcshareddata/xcschemes/MapboxSpeech tvOS.xcscheme
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1010"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DAE35295224213ED00A3FF9C"
+               BuildableName = "MapboxSpeech.framework"
+               BlueprintName = "MapboxSpeechTV"
+               ReferencedContainer = "container:MapboxSpeech.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DAE3529D224213ED00A3FF9C"
+               BuildableName = "MapboxSpeechTests.xctest"
+               BlueprintName = "MapboxSpeechTVTests"
+               ReferencedContainer = "container:MapboxSpeech.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DAE35295224213ED00A3FF9C"
+            BuildableName = "MapboxSpeech.framework"
+            BlueprintName = "MapboxSpeechTV"
+            ReferencedContainer = "container:MapboxSpeech.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DAE35295224213ED00A3FF9C"
+            BuildableName = "MapboxSpeech.framework"
+            BlueprintName = "MapboxSpeechTV"
+            ReferencedContainer = "container:MapboxSpeech.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DAE35295224213ED00A3FF9C"
+            BuildableName = "MapboxSpeech.framework"
+            BlueprintName = "MapboxSpeechTV"
+            ReferencedContainer = "container:MapboxSpeech.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/MapboxSpeech.xcodeproj/xcshareddata/xcschemes/MapboxSpeech watchOS.xcscheme
+++ b/MapboxSpeech.xcodeproj/xcshareddata/xcschemes/MapboxSpeech watchOS.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1010"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DAE352B82242165D00A3FF9C"
+               BuildableName = "MapboxSpeech.framework"
+               BlueprintName = "MapboxSpeechWatch"
+               ReferencedContainer = "container:MapboxSpeech.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DAE352B82242165D00A3FF9C"
+            BuildableName = "MapboxSpeech.framework"
+            BlueprintName = "MapboxSpeechWatch"
+            ReferencedContainer = "container:MapboxSpeech.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DAE352B82242165D00A3FF9C"
+            BuildableName = "MapboxSpeech.framework"
+            BlueprintName = "MapboxSpeechWatch"
+            ReferencedContainer = "container:MapboxSpeech.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/MapboxSpeech/Info.plist
+++ b/MapboxSpeech/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
-	<string>en</string>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -18,6 +18,8 @@
 	<string>0.1.1</string>
 	<key>CFBundleVersion</key>
 	<string>5</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2017–2019 Mapbox. All rights reserved.</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>

--- a/MapboxSpeech/MapboxSpeech.h
+++ b/MapboxSpeech/MapboxSpeech.h
@@ -1,4 +1,4 @@
-#import <UIKit/UIKit.h>
+#import <Foundation/Foundation.h>
 
 //! Project version number for MapboxSpeech.
 FOUNDATION_EXPORT double MapboxSpeechVersionNumber;

--- a/MapboxSpeechTests/Info.plist
+++ b/MapboxSpeechTests/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
-	<string>en</string>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Mapbox Speech
 
-Mapbox Speech connects your iOS application to the Mapbox Voice API. Take turn instructions from the [Mapbox Directions API](https://www.mapbox.com/api-documentation/#directions) and read them aloud naturally in multiple languages. This library is specifically designed to work with [MapboxDirections.swift](https://github.com/mapbox/MapboxDirections.swift/) as part of the [Mapbox Navigation SDK for iOS](https://github.com/mapbox/mapbox-navigation-ios/).
+Mapbox Speech connects your iOS or macOS application to the Mapbox Voice API. Take turn instructions from the [Mapbox Directions API](https://www.mapbox.com/api-documentation/#directions) and read them aloud naturally in multiple languages. This library is specifically designed to work with [MapboxDirections.swift](https://github.com/mapbox/MapboxDirections.swift/) as part of the [Mapbox Navigation SDK for iOS](https://github.com/mapbox/mapbox-navigation-ios/).
 
 ## Getting started
 
@@ -54,6 +54,11 @@ let speechSynthesizer = SpeechSynthesizer.shared
 MBSpeechSynthesizer *speechSynthesizer = [MBSpeechSynthesizer sharedSpeechSynthesizer];
 ```
 
+```applescript
+// AppDelegate.applescript
+set theSpeechSynthesizer to sharedSpeechSynthesizer of MBSpeechSynthesizer of the current application
+```
+
 With the directions object in hand, construct a SpeechOptions or MBSpeechOptions object and pass it into the `SpeechSynthesizer.audioData(with:completionHandler:)` method.
 
 ```swift
@@ -73,7 +78,7 @@ speechSynthesizer.audioData(with: options) { (data: Data?, error: NSError?) in
 ```objc
 // main.m
 
-MBSpeechOptions *options = [[MBSpeechOptions alloc] initWithText: "hello, my name is Bobby"];
+MBSpeechOptions *options = [[MBSpeechOptions alloc] initWithText:"hello, my name is Bobby"];
 [speechSynthesizer audioDataWithOptions:options completionHandler:^(NSData * _Nullable data,
                                                                     NSError * _Nullable error) {
     if (error) {
@@ -83,4 +88,16 @@ MBSpeechOptions *options = [[MBSpeechOptions alloc] initWithText: "hello, my nam
     
     // Do something with the audio!
 }];
+```
+
+```applescript
+// AppDelegate.applescript
+
+set theOptions to alloc of MBSpeechOptions of the current application
+tell theOptions to initWithText:"hello, my name is Bobby"
+
+set theURL to theSpeechSynthesizer's URLForSynthesizingSpeechWithOptions:theOptions
+set theData to the current application's NSData's dataWithContentsOfURL:theURL
+
+// Do something with the audio!
 ```

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Mapbox Speech
 
-Mapbox Speech connects your iOS or macOS application to the Mapbox Voice API. Take turn instructions from the [Mapbox Directions API](https://www.mapbox.com/api-documentation/#directions) and read them aloud naturally in multiple languages. This library is specifically designed to work with [MapboxDirections.swift](https://github.com/mapbox/MapboxDirections.swift/) as part of the [Mapbox Navigation SDK for iOS](https://github.com/mapbox/mapbox-navigation-ios/).
+Mapbox Speech connects your iOS, macOS, or tvOS application to the Mapbox Voice API. Take turn instructions from the [Mapbox Directions API](https://www.mapbox.com/api-documentation/#directions) and read them aloud naturally in multiple languages. This library is specifically designed to work with [MapboxDirections.swift](https://github.com/mapbox/MapboxDirections.swift/) as part of the [Mapbox Navigation SDK for iOS](https://github.com/mapbox/mapbox-navigation-ios/).
 
 ## Getting started
 

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Mapbox Speech
 
-Mapbox Speech connects your iOS, macOS, or tvOS application to the Mapbox Voice API. Take turn instructions from the [Mapbox Directions API](https://www.mapbox.com/api-documentation/#directions) and read them aloud naturally in multiple languages. This library is specifically designed to work with [MapboxDirections.swift](https://github.com/mapbox/MapboxDirections.swift/) as part of the [Mapbox Navigation SDK for iOS](https://github.com/mapbox/mapbox-navigation-ios/).
+Mapbox Speech connects your iOS, macOS, tvOS, or watchOS application to the Mapbox Voice API. Take turn instructions from the [Mapbox Directions API](https://www.mapbox.com/api-documentation/#directions) and read them aloud naturally in multiple languages. This library is specifically designed to work with [MapboxDirections.swift](https://github.com/mapbox/MapboxDirections.swift/) as part of the [Mapbox Navigation SDK for iOS](https://github.com/mapbox/mapbox-navigation-ios/).
 
 ## Getting started
 


### PR DESCRIPTION
Added frameworks that build for macOS, tvOS, and watchOS, which this project’s CocoaPods podspec has claimed to support from the beginning.

/cc @frederoni