### PR TITLE
Prepare release 0.2.0

### DIFF
--- a/MapboxSpeech.podspec
+++ b/MapboxSpeech.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
   # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 
   s.name = "MapboxSpeech"
-  s.version = "0.1.1"
+  s.version = "0.2.0"
 
   s.summary = "A speech synthesizer built on Amazon Polly for Swift and Objective-C."
 

--- a/Sources/MapboxSpeech/Info.plist
+++ b/Sources/MapboxSpeech/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1.1</string>
+	<string>0.2.0</string>
 	<key>CFBundleVersion</key>
 	<string>5</string>
 	<key>NSHumanReadableCopyright</key>

--- a/Tests/MapboxSpeechTests/Info.plist
+++ b/Tests/MapboxSpeechTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1.1</string>
+	<string>0.2.0</string>
 	<key>CFBundleVersion</key>
 	<string>5</string>
 </dict>


### PR DESCRIPTION
Bumped to 0.2.0

- [ ] Rebase atop master when #28 has landed

cc @1ec5