### PR TITLE
Discontinue Objective-C compatibility

### DIFF
--- a/Sources/MapboxSpeech/MBSpeechOptions.swift
+++ b/Sources/MapboxSpeech/MBSpeechOptions.swift
@@ -1,104 +1,29 @@
 import Foundation
 
-@objc(MBTextType)
-public enum TextType: UInt, CustomStringConvertible, Codable {
-    
+public enum TextType: String, Codable {
     case text
-    
     case ssml
-    
-    public init?(description: String) {
-        let type: TextType
-        switch description {
-        case "text":
-            type = .text
-        case "ssml":
-            type = .ssml
-        default:
-            return nil
-        }
-        self.init(rawValue: type.rawValue)
-    }
-    
-    public var description: String {
-        switch self {
-        case .text:
-            return "text"
-        case .ssml:
-            return "ssml"
-        }
-    }
 }
 
-@objc(MBAudioFormat)
-public enum AudioFormat: UInt, CustomStringConvertible, Codable {
-
+public enum AudioFormat: String, Codable {
     case mp3
-    
-    public init?(description: String) {
-        let format: AudioFormat
-        switch description {
-        case "mp3":
-            format = .mp3
-        default:
-            return nil
-        }
-        self.init(rawValue: format.rawValue)
-    }
-    
-    public var description: String {
-        switch self {
-        case .mp3:
-            return "mp3"
-        }
-    }
 }
 
-@objc(MBSpeechGender)
-public enum SpeechGender: UInt, CustomStringConvertible, Codable {
-    
+public enum SpeechGender: String, Codable {
     case female
-    
     case male
-    
     case neuter
-    
-    public init?(description: String) {
-        let gender: SpeechGender
-        switch description {
-        case "female":
-            gender = .female
-        case "male":
-            gender = .male
-        default:
-            gender = .neuter
-        }
-        self.init(rawValue: gender.rawValue)
-    }
-    
-    public var description: String {
-        switch self {
-        case .female:
-            return "female"
-        case .male:
-            return "male"
-        case .neuter:
-            return "neuter"
-        }
-    }
 }
 
-@objc(MBSpeechOptions)
-open class SpeechOptions: NSObject, Codable {
-    
-    @objc public init(text: String) {
+open class SpeechOptions: Codable {
+    public init(text: String) {
         self.text = text
-        self.textType = .text
+        textType = .text
     }
     
-    @objc public init(ssml: String) {
+    public init(ssml: String) {
         self.text = ssml
-        self.textType = .ssml
+        textType = .ssml
     }
     
     /**
@@ -106,35 +31,33 @@ open class SpeechOptions: NSObject, Codable {
      
      If `SSML` is provided, `TextType` must be `TextType.ssml`.
      */
-    @objc open var text: String
-    
+    open var text: String
     
     /**
      Type of text to synthesize.
      
      `SSML` text must be valid `SSML` for request to work.
      */
-    @objc let textType: TextType
-    
+    let textType: TextType
     
     /**
      Audio format for outputted audio file.
      */
-    @objc open var outputFormat: AudioFormat = .mp3
+    open var outputFormat: AudioFormat = .mp3
     
     /**
      The locale in which the audio is spoken.
      
      By default, the user's system locale will be used to decide upon an appropriate voice.
      */
-    @objc open var locale: Locale = Locale.autoupdatingCurrent
+    open var locale: Locale = .autoupdatingCurrent
     
     /**
      Gender of voice speeking text.
      
      Note: not all languages have both genders.
      */
-    @objc open var speechGender: SpeechGender = .neuter
+    open var speechGender: SpeechGender = .neuter
     
     /**
      The path of the request URL, not including the hostname or any parameters.

--- a/Tests/MapboxSpeechTests/MapboxVoiceTests.swift
+++ b/Tests/MapboxSpeechTests/MapboxVoiceTests.swift
@@ -41,7 +41,7 @@ class MapboxVoiceTests: XCTestCase {
         options.locale = Locale(identifier: "en_US")
         
         var audio: Data?
-        let task = voice.audioData(with: options) { (data: Data?, error: NSError?) in
+        let task = voice.audioData(with: options) { (data: Data?, error: SpeechError?) in
             XCTAssertNil(error)
             XCTAssertNotNil(data)
             audio = data!

--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,8 @@
 
 Mapbox Speech connects your iOS, macOS, tvOS, or watchOS application to the Mapbox Voice API. Take turn instructions from the [Mapbox Directions API](https://www.mapbox.com/api-documentation/#directions) and read them aloud naturally in multiple languages. This library is specifically designed to work with [MapboxDirections.swift](https://github.com/mapbox/MapboxDirections.swift/) as part of the [Mapbox Navigation SDK for iOS](https://github.com/mapbox/mapbox-navigation-ios/).
 
+This library is compatible with applications written in Swift. Version 2.0 was the last version of this library to support applications written in Objective-C or AppleScript.
+
 ## Getting started
 
 Specify the following dependency in your [Carthage](https://github.com/Carthage/Carthage) Cartfile:
@@ -28,24 +30,14 @@ Then `import MapboxSpeech` or `@import MapboxSpeech;`.
 
 You’ll need a [Mapbox access token](https://www.mapbox.com/developers/api/#access-tokens) in order to use the API. If you’re already using the [Mapbox Maps SDK for iOS](https://www.mapbox.com/ios-sdk/) or [macOS SDK](https://mapbox.github.io/mapbox-gl-native/macos/), Mapbox Speech automatically recognizes your access token, as long as you’ve placed it in the `MGLMapboxAccessToken` key of your application’s Info.plist file.
 
-The examples below are each provided in Swift (denoted with `main.swift`) and Objective-C (`main.m`).
-
 ### Basics
 
-The main speech synthesis class is SpeechSynthesizer (in Swift) or MBSpeechSynthesizer (in Objective-C). Create a speech synthesizer object using your access token:
+The main speech synthesis class is `SpeechSynthesizer`. Create a speech synthesizer object using your access token:
 
 ```swift
-// main.swift
 import MapboxSpeech
 
 let speechSynthesizer = SpeechSynthesizer(accessToken: "<#your access token#>")
-```
-
-```objc
-// main.m
-@import MapboxSpeech;
-
-MBSpeechSynthesizer *speechSynthesizer = [[MBSpeechSynthesizer alloc] initWithAccessToken:@"<#your access token#>"];
 ```
 
 Alternatively, you can place your access token in the `MGLMapboxAccessToken` key of your application’s Info.plist file, then use the shared speech synthesizer object:
@@ -53,16 +45,6 @@ Alternatively, you can place your access token in the `MGLMapboxAccessToken` key
 ```swift
 // main.swift
 let speechSynthesizer = SpeechSynthesizer.shared
-```
-
-```objc
-// main.m
-MBSpeechSynthesizer *speechSynthesizer = [MBSpeechSynthesizer sharedSpeechSynthesizer];
-```
-
-```applescript
-// AppDelegate.applescript
-set theSpeechSynthesizer to sharedSpeechSynthesizer of MBSpeechSynthesizer of the current application
 ```
 
 With the directions object in hand, construct a SpeechOptions or MBSpeechOptions object and pass it into the `SpeechSynthesizer.audioData(with:completionHandler:)` method.
@@ -79,31 +61,4 @@ speechSynthesizer.audioData(with: options) { (data: Data?, error: NSError?) in
     
     // Do something with the audio!
 }
-```
-
-```objc
-// main.m
-
-MBSpeechOptions *options = [[MBSpeechOptions alloc] initWithText:"hello, my name is Bobby"];
-[speechSynthesizer audioDataWithOptions:options completionHandler:^(NSData * _Nullable data,
-                                                                    NSError * _Nullable error) {
-    if (error) {
-        NSLog(@"Error synthesizing speech: %@", error);
-        return;
-    }
-    
-    // Do something with the audio!
-}];
-```
-
-```applescript
--- AppDelegate.applescript
-
-set theOptions to alloc of MBSpeechOptions of the current application
-tell theOptions to initWithText:"hello, my name is Bobby"
-
-set theURL to theSpeechSynthesizer's URLForSynthesizingSpeechWithOptions:theOptions
-set theData to the current application's NSData's dataWithContentsOfURL:theURL
-
--- Do something with the audio!
 ```


### PR DESCRIPTION
With this PR, the public API no longer bridges to Objective-C. Additionally, the library relies more heavily on Codable and pure Swift enumerations.

/ref mapbox/MapboxDirections.swift#381
/cc @JThramer