### PR TITLE
Guard against new/unrecognized platforms and architectures when building a user agent string

### DIFF
--- a/Sources/MapboxSpeech/MapboxSpeech.swift
+++ b/Sources/MapboxSpeech/MapboxSpeech.swift
@@ -20,8 +20,10 @@ let userAgent: String = {
         components.append("\(libraryName)/\(version)")
     }
     
+    // `ProcessInfo().operatingSystemVersionString` can replace this when swift-corelibs-foundaton is next released:
+    // https://github.com/apple/swift-corelibs-foundation/blob/main/Sources/Foundation/ProcessInfo.swift#L104-L202
     let system: String
-    #if os(OSX)
+    #if os(macOS)
         system = "macOS"
     #elseif os(iOS)
         system = "iOS"
@@ -31,6 +33,8 @@ let userAgent: String = {
         system = "tvOS"
     #elseif os(Linux)
         system = "Linux"
+    #else
+        system = "unknown"
     #endif
     let systemVersion = ProcessInfo().operatingSystemVersion
     components.append("\(system)/\(systemVersion.majorVersion).\(systemVersion.minorVersion).\(systemVersion.patchVersion)")
@@ -44,6 +48,9 @@ let userAgent: String = {
         chip = "arm64"
     #elseif arch(i386)
         chip = "i386"
+    #else
+        // Maybe fall back on `uname(2).machine`?
+        chip = "unrecognized"
     #endif
     components.append("(\(chip))")
     


### PR DESCRIPTION
Without the `#else` clauses, any OS or CPU architecture not already listed causes a build failure. This already occurs in Xcode 12.2b3 when it attempts to build an `arm64_32` architecture slice for watchOS - and of course, Windows is not listed as an OS platform (I didn't try building there, but it'd certainly be interesting!).

Unfortunately, many of the newer OS names (Windows, Android, WASI, etc.) did not appear until Swift 5.2 and 5.3. Worse, sometimes CPU architecture names are not available in every toolchain, even for the same Swift version - the aforementioned `arm64_32` variant is not present in Swift's source code, for example, and is presumably restricted to Xcode's built-in toolchain at the present time.

As a result, it is counterproductive to add additional conditions, since they'd just cause different build failures elsewhere, so this PR only adds the fallback cases. `ProcessInfo`'s `operatingSystemVersionString` property will begin providing much more robust output than it does in its present form in a future Swift release, probably the next minor update; it can then replace and improve upon the current use of platform conditionals and manually rendering the OS' version string. 