### PR TITLE
Fix/locale codes

### DIFF
--- a/Sources/MapboxSpeech/MBSpeechOptions.swift
+++ b/Sources/MapboxSpeech/MBSpeechOptions.swift
@@ -74,7 +74,7 @@ open class SpeechOptions: Codable {
     internal var params: [URLQueryItem] {
         var params: [URLQueryItem] = [
             URLQueryItem(name: "textType", value: String(describing: textType)),
-            URLQueryItem(name: "language", value: locale.identifier),
+            URLQueryItem(name: "language", value: locale.amazonIdentifier),
             URLQueryItem(name: "outputFormat", value: String(describing: outputFormat))
         ]
         
@@ -85,3 +85,31 @@ open class SpeechOptions: Codable {
         return params
     }
 }
+
+public extension Locale {
+    
+    /**
+     `String` Returns the identifier of the locale identifier supported by Amazon Polly [`Supported Language`](https://docs.aws.amazon.com/polly/latest/dg/SupportedLanguage.html).
+     
+     While common language identifiers are two-letter `ISO 639-1` standard, three-letter `ISO 639-2` standard or even `RFC 4647` (known as BCP 47), `Amazon Polly` uses `ISO 639-3`
+     W3C language identification which creates incompatibility with `Locale.current`.
+     This computed property either return `Locale.identifier` or the supported version of the unknown code.
+     List of currently unsupported codes :
+     "ar-SA", "zh-CN", "zh-HK", "zh-Hans", "zh-Hant", "zh-TW"
+     */
+    var amazonIdentifier : String {
+        let unsupported : Dictionary<String, String> = [
+            "ar-SA" : "arb",
+            "zh-CN" : "cmn-CN",
+            "zh-HK" : "cmn-CN",
+            "zh-Hans" : "cmn-CN" ,
+            "zh-Hant" : "cmn-CN",
+            "zh-TW" : "cmn-CN",
+        ]
+        if unsupported.keys.contains(self.identifier), let patchedIdentifier = unsupported[ self.identifier ] {
+            return patchedIdentifier
+        }
+        return self.identifier
+    }
+}
+

--- a/Sources/MapboxSpeech/MBSpeechOptions.swift
+++ b/Sources/MapboxSpeech/MBSpeechOptions.swift
@@ -99,15 +99,14 @@ public extension Locale {
      */
     var amazonIdentifier : String {
         let unsupported : Dictionary<String, String> = [
-            "ar-SA" : "arb",
-            "zh-CN" : "cmn-CN",
-            "zh-HK" : "cmn-CN",
-            "zh-Hans" : "cmn-CN" ,
-            "zh-Hant" : "cmn-CN",
-            "zh-TW" : "cmn-CN",
+            "ar"     : "arb",
+            "zh"     : "cmn-CN"
         ]
-        if unsupported.keys.contains(self.identifier), let patchedIdentifier = unsupported[ self.identifier ] {
-            return patchedIdentifier
+        let languageComponents = Locale.components(fromIdentifier: self.identifier)
+        if let languageCode = languageComponents["kCFLocaleLanguageCodeKey"] {
+            if unsupported.keys.contains(languageCode), let patchedIdentifier = unsupported[ languageCode ] {
+                return patchedIdentifier
+            }
         }
         return self.identifier
     }

--- a/Sources/MapboxSpeechCLI/main.swift
+++ b/Sources/MapboxSpeechCLI/main.swift
@@ -18,6 +18,11 @@ let text = CommandLine.arguments[1]
 let options = SpeechOptions(text: text)
 var speech = SpeechSynthesizer(accessToken: token)
 
+if CommandLine.arguments.count > 2 {
+    let language = CommandLine.arguments[2]
+    options.locale = .init(identifier: language)
+}
+
 let url = speech.url(forSynthesizing: options)
 print("URL: \(url)")
 


### PR DESCRIPTION
**Description**
This PR fixes an issue with incompatible [ISO 639-3](https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPInternational/LanguageandLocaleIDs/LanguageandLocaleIDs.html) codes between iOS's [Locale](https://developer.apple.com/documentation/foundation/locale) and Amazon Polly's [ISO 639-3](https://docs.aws.amazon.com/polly/latest/dg/SupportedLanguage.html).
It was also reported [here](https://github.com/mapbox/mapbox-navigation-ios/issues/1977#issuecomment-809467252). 

**Implementation**
- [ ] Store all unsupported language codes returned by Locale in ISO 639-2 format.
- [ ] If SpeechOptions's language identifier is in the list of unsupported, use the supported one instead.
- [ ] Support Arabic (AR) and Chinese (ZH) codes
- [ ] Add support for other unsupported languages